### PR TITLE
[SC-383] Update cfn helper scripts for ubuntu 22.04

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -40,9 +40,8 @@
 
     - name: Make aws apps directory
       ansible.builtin.file:
-        path: /opt/aws/bin
+        path: /opt/aws
         state: directory
-        mode: '0755'
 
     # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-helper-scripts-reference.html
     - name: Download CFN helper scripts
@@ -54,4 +53,9 @@
     - name: Install CFN helper scripts
       ansible.builtin.pip:
         name: file:///tmp/aws-cfn-bootstrap-py3-latest.tar.gz
-        extra_args: "--target=/opt/aws/bin"
+
+    - name: Create CFN helper symbolic link
+      ansible.builtin.file:
+        src: "/usr/local/init/ubuntu/cfn-hup"
+        dest: "/etc/init.d/cfn-hup"
+        state: link


### PR DESCRIPTION
The CFN helper script is failing to run on ubuntu 22.04 with error..

```
Command: ['/var/lib/cloud/instance/scripts/part-001']
Exit code: 127
Reason: -
Stdout: -
Stderr: -
--
  File "/usr/lib/python3/dist-packages/cloudinit/helpers.py", line 185, in run
    results = functor(*args)
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_scripts_user.py", line 54, in handle
    subp.runparts(runparts_path)
  File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 427, in runparts
    raise RuntimeError(
RuntimeError: Runparts: 1 failures (part-001) in 1 attempted commands
2023-06-12 18:53:32,520 - modules.py[DEBUG]: Running module ssh-authkey-fingerprin
```

This is most likely due to cfn helper script not being installed correctly on Jammy. Update ansible to match the AWS example[1] to install cfn helper scripts.  The example is provided by AWS install cloudformation scripts doc[2]

[1] https://github.com/awslabs/aws-cloudformation-templates/blob/master/aws/solutions/OperatingSystems/Ubuntu22.04_cfn-hup.yaml
[2] https://repost.aws/knowledge-center/install-cloudformation-scripts

