### PR TITLE
[IT-3547] try to fix ci/cd failure

### DIFF
--- a/src/playbook.yaml
+++ b/src/playbook.yaml
@@ -3,6 +3,12 @@
   become: true
 
   tasks:
+    - name: Upgrade all packages
+      ansible.builtin.apt:
+        name: "*"
+        state: latest
+        update_cache: true
+
     - name: Install packages
       ansible.builtin.apt:
         state: present

--- a/src/template.json
+++ b/src/template.json
@@ -30,7 +30,7 @@
         },
         "most_recent": true,
         "owners": [
-          "099720109477"
+          "amazon"
         ]
       },
       "ssh_username": "{{user `SshUsername`}}",
@@ -53,6 +53,12 @@
     }
   ],
   "provisioners": [
+    {
+      "inline": [
+        "cloud-init status --wait"
+      ],
+      "type": "shell"
+    },
     {
       "extra_arguments": [
         "-v",


### PR DESCRIPTION
The ansible playbook is failing in the github action, but I've been unable to replicate the failure locally. Attempt to fix the issue by upgrading all packages, and adding a provisioner to wait for cloud-init to finish, copied from https://developer.hashicorp.com/packer/docs/debugging#issues-installing-ubuntu-packages

Also specify amazon as the source ami owner by name for clarity.
